### PR TITLE
Optimize SignWriting similarity metric

### DIFF
--- a/signwriting_evaluation/metrics/similarity.py
+++ b/signwriting_evaluation/metrics/similarity.py
@@ -19,7 +19,12 @@ class SymbolAttributes(NamedTuple):
     parallel: bool
 
 
-EnrichedSymbol = tuple[str, SymbolAttributes, Optional[int], int, int]
+class EnrichedSymbol(NamedTuple):
+    symbol: str
+    attributes: SymbolAttributes
+    shape_class: Optional[int]
+    x: int
+    y: int
 
 
 SYMBOL_CLASSES = {
@@ -96,7 +101,7 @@ class SignWritingSimilarityMetric(SignWritingMetric):
         x, y = symbol["position"]
         attributes = get_symbol_attributes(symbol_id)
         shape_class = get_shape_class_index(attributes.shape)
-        return symbol_id, attributes, shape_class, x, y
+        return EnrichedSymbol(symbol_id, attributes, shape_class, x, y)
 
     @staticmethod
     def enrich_sign(sign: Sign) -> list[EnrichedSymbol]:
@@ -115,24 +120,24 @@ class SignWritingSimilarityMetric(SignWritingMetric):
         return sign
 
     def calculate_distance(self, hyp, ref, fallback_distance=None) -> float:
-        hyp_symbol, hyp_attributes, hyp_class, hyp_x, hyp_y = self._coerce_symbol(hyp)
-        ref_symbol, ref_attributes, ref_class, ref_x, ref_y = self._coerce_symbol(ref)
+        hyp_symbol = self._coerce_symbol(hyp)
+        ref_symbol = self._coerce_symbol(ref)
 
-        if (hyp_symbol == ref_symbol and hyp_x == ref_x and hyp_y == ref_y and hyp_class is not None
-                and ref_class is not None):
+        if (hyp_symbol.symbol == ref_symbol.symbol and hyp_symbol.x == ref_symbol.x and hyp_symbol.y == ref_symbol.y
+                and hyp_symbol.shape_class is not None and ref_symbol.shape_class is not None):
             return 0.0
 
-        if hyp_class is None or ref_class is None:
+        if hyp_symbol.shape_class is None or ref_symbol.shape_class is None:
             return self.max_distance if fallback_distance is None else fallback_distance
 
-        symbols_distance = fast_symbol_distance(hyp_attributes, ref_attributes)
+        symbols_distance = fast_symbol_distance(hyp_symbol.attributes, ref_symbol.attributes)
 
-        dx = hyp_x - ref_x
-        dy = hyp_y - ref_y
+        dx = hyp_symbol.x - ref_symbol.x
+        dy = hyp_symbol.y - ref_symbol.y
         position_euclidean = math.sqrt(dx * dx + dy * dy)
         position_distance = ERROR_WEIGHT["positional"] * position_euclidean
 
-        class_penalty = abs(hyp_class - ref_class) * ERROR_WEIGHT["class_penalty"]
+        class_penalty = abs(hyp_symbol.shape_class - ref_symbol.shape_class) * ERROR_WEIGHT["class_penalty"]
 
         return symbols_distance + position_distance + class_penalty
 
@@ -150,27 +155,30 @@ class SignWritingSimilarityMetric(SignWritingMetric):
         ref_len = len(ref_symbols)
         return abs(hyp_len - ref_len) / (max(hyp_len, ref_len) + 1)
 
-    def error_rate(self, hyp, ref) -> float:
-        hyp_symbols = self._coerce_sign(hyp)
-        ref_symbols = self._coerce_sign(ref)
+    def mean_symbol_cost(self, hyp_symbols, ref_symbols) -> float:
         hyp_len = len(hyp_symbols)
         ref_len = len(ref_symbols)
 
-        if not hyp_len or not ref_len:
+        if hyp_len == 1 and ref_len == 1:
+            return self.symbols_score(hyp_symbols[0], ref_symbols[0])
+
+        cost_matrix = np.empty((hyp_len, ref_len), dtype=np.float64)
+        for i, hyp_symbol in enumerate(hyp_symbols):
+            row = cost_matrix[i]
+            for j, ref_symbol in enumerate(ref_symbols):
+                row[j] = self.symbols_score(hyp_symbol, ref_symbol)
+
+        row_ind, col_ind = linear_sum_assignment(cost_matrix)
+        return float(cost_matrix[row_ind, col_ind].mean())
+
+    def error_rate(self, hyp, ref) -> float:
+        hyp_symbols = self._coerce_sign(hyp)
+        ref_symbols = self._coerce_sign(ref)
+
+        if not hyp_symbols or not ref_symbols:
             return 1.0
 
-        if hyp_len == 1 and ref_len == 1:
-            mean_cost = self.symbols_score(hyp_symbols[0], ref_symbols[0])
-        else:
-            cost_matrix = np.empty((hyp_len, ref_len), dtype=np.float64)
-            for i, hyp_symbol in enumerate(hyp_symbols):
-                row = cost_matrix[i]
-                for j, ref_symbol in enumerate(ref_symbols):
-                    row[j] = self.symbols_score(hyp_symbol, ref_symbol)
-
-            row_ind, col_ind = linear_sum_assignment(cost_matrix)
-            mean_cost = float(cost_matrix[row_ind, col_ind].mean())
-
+        mean_cost = self.mean_symbol_cost(hyp_symbols, ref_symbols)
         length_error = self.length_acc(hyp_symbols, ref_symbols)
         length_weight = length_error ** ERROR_WEIGHT["exp_factor"]
         return length_weight + mean_cost * (1.0 - length_weight)
@@ -179,7 +187,7 @@ class SignWritingSimilarityMetric(SignWritingMetric):
         hyp_symbols = self.enrich_sign(fsw_to_sign(hypothesis))
         ref_symbols = self.enrich_sign(fsw_to_sign(reference))
 
-        if hypothesis == reference and hyp_symbols and all(symbol[2] is not None for symbol in hyp_symbols):
+        if hypothesis == reference and hyp_symbols and all(symbol.shape_class is not None for symbol in hyp_symbols):
             return 1.0
 
         score = 1.0 - self.error_rate(hyp_symbols, ref_symbols)
@@ -194,17 +202,21 @@ class SignWritingSimilarityMetric(SignWritingMetric):
         if len(hypothesis_signs) == 1 and len(reference_signs) == 1:
             return self.score_single_sign(hypothesis_signs[0], reference_signs[0])
 
-        hyp_enriched = [self.enrich_sign(fsw_to_sign(sign)) for sign in hypothesis_signs]
-        ref_enriched = [self.enrich_sign(fsw_to_sign(sign)) for sign in reference_signs]
-        matrix_size = max(len(hyp_enriched), len(ref_enriched))
+        return self.mean_sign_score(
+            [self.enrich_sign(fsw_to_sign(sign)) for sign in hypothesis_signs],
+            [self.enrich_sign(fsw_to_sign(sign)) for sign in reference_signs],
+        )
+
+    def mean_sign_score(self, hyp_signs, ref_signs) -> float:
+        matrix_size = max(len(hyp_signs), len(ref_signs))
 
         if matrix_size == 0:
             return 0.0
 
         cost_matrix = np.zeros((matrix_size, matrix_size), dtype=np.float64)
-        for i, hyp_sign in enumerate(hyp_enriched):
+        for i, hyp_sign in enumerate(hyp_signs):
             row = cost_matrix[i]
-            for j, ref_sign in enumerate(ref_enriched):
+            for j, ref_sign in enumerate(ref_signs):
                 score = 1.0 - self.error_rate(hyp_sign, ref_sign)
                 row[j] = score * score
 

--- a/signwriting_evaluation/metrics/similarity.py
+++ b/signwriting_evaluation/metrics/similarity.py
@@ -1,6 +1,6 @@
 import math
 from functools import cache
-from typing import Tuple, Optional, NamedTuple
+from typing import NamedTuple, Optional
 
 import numpy as np
 from scipy.optimize import linear_sum_assignment
@@ -17,6 +17,9 @@ class SymbolAttributes(NamedTuple):
     facing: int
     angle: int
     parallel: bool
+
+
+EnrichedSymbol = tuple[str, SymbolAttributes, Optional[int], int, int]
 
 
 SYMBOL_CLASSES = {
@@ -47,15 +50,6 @@ def get_symbol_attributes(symbol: str) -> SymbolAttributes:
     angle = int(symbol[5], 16)
     parallel = facing > 2
     return SymbolAttributes(shape, facing, angle, parallel)
-
-
-@cache
-def fast_positional_distance(pos1: Tuple[int, int], pos2: Tuple[int, int]) -> float:
-    # Unbelievably, this is faster than using numpy or scipy for simple Euclidean distance
-    # It reduces the overhead of converting to numpy arrays when calculating distances
-    dx = pos1[0] - pos2[0]
-    dy = pos1[1] - pos2[1]
-    return math.sqrt(dx * dx + dy * dy)
 
 
 ERROR_WEIGHT = {
@@ -90,83 +84,130 @@ class SignWritingSimilarityMetric(SignWritingMetric):
 
     def __init__(self):
         super().__init__("SymbolsDistances")
-        self.max_distance = self.calculate_distance({"symbol": "S10000", "position": (250, 250)},
-                                                    {"symbol": "S38b07", "position": (750, 750)})
+        self.max_distance = self.calculate_distance(
+            self.enrich_symbol({"symbol": "S10000", "position": (250, 250)}),
+            self.enrich_symbol({"symbol": "S38b07", "position": (750, 750)}),
+            fallback_distance=0.0,
+        )
 
-    def calculate_distance(self, hyp: SignSymbol, ref: SignSymbol) -> float:
-        hyp_attributes = get_symbol_attributes(hyp['symbol'])
-        ref_attributes = get_symbol_attributes(ref['symbol'])
+    @staticmethod
+    def enrich_symbol(symbol: SignSymbol) -> EnrichedSymbol:
+        symbol_id = symbol["symbol"]
+        x, y = symbol["position"]
+        attributes = get_symbol_attributes(symbol_id)
+        shape_class = get_shape_class_index(attributes.shape)
+        return symbol_id, attributes, shape_class, x, y
+
+    @staticmethod
+    def enrich_sign(sign: Sign) -> list[EnrichedSymbol]:
+        return [SignWritingSimilarityMetric.enrich_symbol(symbol) for symbol in sign["symbols"]]
+
+    @staticmethod
+    def _coerce_symbol(symbol) -> EnrichedSymbol:
+        if isinstance(symbol, tuple):
+            return symbol
+        return SignWritingSimilarityMetric.enrich_symbol(symbol)
+
+    @staticmethod
+    def _coerce_sign(sign) -> list[EnrichedSymbol]:
+        if isinstance(sign, dict):
+            return SignWritingSimilarityMetric.enrich_sign(sign)
+        return sign
+
+    def calculate_distance(self, hyp, ref, fallback_distance=None) -> float:
+        hyp_symbol, hyp_attributes, hyp_class, hyp_x, hyp_y = self._coerce_symbol(hyp)
+        ref_symbol, ref_attributes, ref_class, ref_x, ref_y = self._coerce_symbol(ref)
+
+        if (hyp_symbol == ref_symbol and hyp_x == ref_x and hyp_y == ref_y and hyp_class is not None
+                and ref_class is not None):
+            return 0.0
+
+        if hyp_class is None or ref_class is None:
+            return self.max_distance if fallback_distance is None else fallback_distance
 
         symbols_distance = fast_symbol_distance(hyp_attributes, ref_attributes)
 
-        position_euclidean = fast_positional_distance(hyp["position"], ref["position"])
+        dx = hyp_x - ref_x
+        dy = hyp_y - ref_y
+        position_euclidean = math.sqrt(dx * dx + dy * dy)
         position_distance = ERROR_WEIGHT["positional"] * position_euclidean
-
-        hyp_class = get_shape_class_index(hyp_attributes.shape)
-        ref_class = get_shape_class_index(ref_attributes.shape)
-
-        if hyp_class is None or ref_class is None:
-            return self.max_distance
 
         class_penalty = abs(hyp_class - ref_class) * ERROR_WEIGHT["class_penalty"]
 
         return symbols_distance + position_distance + class_penalty
 
     def normalized_distance(self, unnormalized: float) -> float:
-        return pow(unnormalized / self.max_distance, ERROR_WEIGHT["normalized_factor"])
+        return (unnormalized / self.max_distance) ** ERROR_WEIGHT["normalized_factor"]
 
-    def symbols_score(self, hyp: SignSymbol, ref: SignSymbol) -> float:
+    def symbols_score(self, hyp, ref) -> float:
         distance = self.calculate_distance(hyp, ref)
-        normalized = self.normalized_distance(distance)
-        return normalized
+        return self.normalized_distance(distance)
 
-    def length_acc(self, hyp: Sign, ref: Sign) -> float:
-        hyp_len = len(hyp["symbols"])
-        ref_len = len(ref["symbols"])
-        # plus 1 for the box symbol
+    def length_acc(self, hyp, ref) -> float:
+        hyp_symbols = self._coerce_sign(hyp)
+        ref_symbols = self._coerce_sign(ref)
+        hyp_len = len(hyp_symbols)
+        ref_len = len(ref_symbols)
         return abs(hyp_len - ref_len) / (max(hyp_len, ref_len) + 1)
 
-    def error_rate(self, hyp: Sign, ref: Sign) -> float:
-        # Calculate the evaluate score for a given hypothesis and ref.
-        if not hyp["symbols"] or not ref["symbols"]:
+    def error_rate(self, hyp, ref) -> float:
+        hyp_symbols = self._coerce_sign(hyp)
+        ref_symbols = self._coerce_sign(ref)
+        hyp_len = len(hyp_symbols)
+        ref_len = len(ref_symbols)
+
+        if not hyp_len or not ref_len:
             return 1.0
 
-        cost_matrix = np.array(
-            [self.symbols_score(first, second) for first in hyp["symbols"] for second in ref["symbols"]])
-        cost_matrix = cost_matrix.reshape(len(hyp["symbols"]), -1)
-        # Find the lowest cost matching
-        row_ind, col_ind = linear_sum_assignment(cost_matrix)
-        mean_cost = float(cost_matrix[row_ind, col_ind].mean())
+        if hyp_len == 1 and ref_len == 1:
+            mean_cost = self.symbols_score(hyp_symbols[0], ref_symbols[0])
+        else:
+            cost_matrix = np.empty((hyp_len, ref_len), dtype=np.float64)
+            for i, hyp_symbol in enumerate(hyp_symbols):
+                row = cost_matrix[i]
+                for j, ref_symbol in enumerate(ref_symbols):
+                    row[j] = self.symbols_score(hyp_symbol, ref_symbol)
 
-        length_error = self.length_acc(hyp, ref)
-        length_weight = pow(length_error, ERROR_WEIGHT["exp_factor"])
-        return length_weight + mean_cost * (1 - length_weight)
+            row_ind, col_ind = linear_sum_assignment(cost_matrix)
+            mean_cost = float(cost_matrix[row_ind, col_ind].mean())
+
+        length_error = self.length_acc(hyp_symbols, ref_symbols)
+        length_weight = length_error ** ERROR_WEIGHT["exp_factor"]
+        return length_weight + mean_cost * (1.0 - length_weight)
 
     def score_single_sign(self, hypothesis: str, reference: str) -> float:
-        # Calculate the evaluate score for a given hypothesis and ref.
-        hyp = fsw_to_sign(hypothesis)
-        ref = fsw_to_sign(reference)
-        return pow(1 - self.error_rate(hyp, ref), 2)
+        hyp_symbols = self.enrich_sign(fsw_to_sign(hypothesis))
+        ref_symbols = self.enrich_sign(fsw_to_sign(reference))
+
+        if hypothesis == reference and hyp_symbols and all(symbol[2] is not None for symbol in hyp_symbols):
+            return 1.0
+
+        score = 1.0 - self.error_rate(hyp_symbols, ref_symbols)
+        return score * score
 
     def score(self, hypothesis: Optional[str], reference: Optional[str]) -> float:
         if hypothesis is None or reference is None:
             return 0.0
 
-        # Here, hypothesis and reference are both FSW strings of potentially different number of signs
         hypothesis_signs = text_to_signs(hypothesis)
         reference_signs = text_to_signs(reference)
         if len(hypothesis_signs) == 1 and len(reference_signs) == 1:
             return self.score_single_sign(hypothesis_signs[0], reference_signs[0])
 
-        # Pad with empty strings to make sure the number of signs is the same
-        if len(hypothesis_signs) != len(reference_signs):
-            max_length = max(len(hypothesis_signs), len(reference_signs))
-            hypothesis_signs += tuple([None] * (max_length - len(hypothesis_signs)))
-            reference_signs += tuple([None] * (max_length - len(reference_signs)))
+        hyp_enriched = [self.enrich_sign(fsw_to_sign(sign)) for sign in hypothesis_signs]
+        ref_enriched = [self.enrich_sign(fsw_to_sign(sign)) for sign in reference_signs]
+        matrix_size = max(len(hyp_enriched), len(ref_enriched))
 
-        # Match each hypothesis sign with each reference sign
-        cost_matrix = self.score_all(hypothesis_signs, reference_signs, progress_bar=False)
-        cost_matrix = np.array(cost_matrix)
-        row_ind, col_ind = linear_sum_assignment(1 - cost_matrix)
+        if matrix_size == 0:
+            return 0.0
+
+        cost_matrix = np.zeros((matrix_size, matrix_size), dtype=np.float64)
+        for i, hyp_sign in enumerate(hyp_enriched):
+            row = cost_matrix[i]
+            for j, ref_sign in enumerate(ref_enriched):
+                score = 1.0 - self.error_rate(hyp_sign, ref_sign)
+                row[j] = score * score
+
+        row_ind, col_ind = linear_sum_assignment(1.0 - cost_matrix)
         mean_score = cost_matrix[row_ind, col_ind].mean()
         return float(mean_score)

--- a/signwriting_evaluation/metrics/test_similarity.py
+++ b/signwriting_evaluation/metrics/test_similarity.py
@@ -81,6 +81,31 @@ class TestSignWritingSymbolDistance(unittest.TestCase):
         score = self.metric.score(hypothesis, reference)
         self.assertEqual(score, 0)
 
+    def test_matches_legacy_scores(self):
+        base = "M530x538S37602508x462S15a11493x494S20e00488x510S22f03469x517"
+        reference = "M519x534S37900497x466S3770b497x485S15a51491x501S22f03481x513"
+        different_shape_hypothesis = "M530x538S17600508x462S15a11493x494S20e00488x510S22f03469x517"
+        different_shape_reference = "M530x538S17600508x462S12a11493x494S20e00488x510S22f13469x517"
+        cases = [
+            (base, reference, 0.5557001288803375),
+            (base, base, 1.0),
+            (base, "M530x538S22f03469x517S37602508x462S20e00488x510S15a11493x494", 1.0),
+            (different_shape_hypothesis, different_shape_reference, 0.8210067817002714),
+            (
+                f"{different_shape_hypothesis} {different_shape_hypothesis}",
+                different_shape_reference,
+                0.4105033908501357,
+            ),
+            (f"{different_shape_hypothesis} {different_shape_reference}",
+             f"{different_shape_reference} {different_shape_hypothesis}", 1.0),
+            ("M<s><s>M<s>p483", "M<s><s>M<s>p483", 0.0),
+            ("M530x538S38c00508x462", "M530x538S10000508x462", 0.0),
+            ("M530x538S38c00508x462", "M530x538S38c00508x462", 0.0),
+        ]
+        for hypothesis, reference, expected in cases:
+            with self.subTest(hypothesis=hypothesis, reference=reference):
+                self.assertAlmostEqual(self.metric.score(hypothesis, reference), expected, places=12)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- Replace the SignWriting similarity metric internals with an enriched-symbol implementation that keeps the existing `SignWritingSimilarityMetric` public API.
- Avoid repeated sign parsing and object reconstruction inside the pairwise distance loops.
- Keep the old method names (`calculate_distance`, `symbols_score`, `length_acc`, `error_rate`, `score_single_sign`, `score`) while making them operate on enriched symbols/signs where possible.
- Add regression coverage for legacy score outputs, including multi-sign, malformed FSW, SWU input, and unknown-symbol cases.

## Relationship to signwriting parser PR
This optimization benefits from the faster `fsw_to_sign` parser in sign-language-processing/signwriting#16. The direct metric benchmarks below were run with that branch on `PYTHONPATH`, so this should be reviewed together with that parser change.

## Correctness
- Focused tests pass: `PYTHONPATH=/home/shaltiel/signwriting /home/shaltiel/tmp/.venv/bin/python -m unittest signwriting_evaluation.metrics.test_similarity`
- Direct old-vs-new comparison against `main:signwriting_evaluation/metrics/similarity.py` matched exactly across 1,000 sampled train-sign pairs: `max_abs_diff = 0.0` and equality to 12 decimal places.

## Performance
The apples-to-apples comparison is direct `SignWritingSimilarityMetric.score(...)` throughput, using the optimized parser from signwriting#16 for both old and new metric implementations. The Hugging Face/evaluate public `compute()` wrapper is a separate source of overhead when called once per pair, so it is not the right baseline for this PR.

Local benchmark results:

- Deterministic random validation-vs-train pairs, 100,000 comparisons, separate Python processes:
  - old `main` metric: 9,973 comparisons/sec
  - optimized metric: 14,326 comparisons/sec
  - speedup: 1.44x
  - checksums matched exactly

- `signwriting_eval_benchmark.py`-style unique-train pair sequence, 10 seconds per implementation, separate Python processes:
  - old `main` metric: 10,929 comparisons/sec
  - optimized metric: 13,482 comparisons/sec
  - speedup: 1.23x

A separate local run reported by Shaltiel measured about 13.5k comparisons/sec for the old metric and 18.5k comparisons/sec for the optimized metric, a 1.37x speedup. The exact rate is workload/cache dependent, but the realistic direct-metric improvement is roughly 1.2x-1.4x rather than the much larger number implied by comparing against per-pair `evaluate.compute()` overhead.

## Validation Notes
Full unittest discovery currently fails in unrelated CLIP tests due to a local CuDNN runtime mismatch (`CUDNN_STATUS_SUBLIBRARY_VERSION_MISMATCH`). The similarity tests pass.
