### PR TITLE
release: universal2 macOS wheel (avoid stalled Intel-mac runners)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,8 +18,9 @@ jobs:
         platform:
           - { runner: ubuntu-latest,  target: x86_64 }
           - { runner: ubuntu-latest,  target: aarch64 }
-          - { runner: macos-13,       target: x86_64 }
-          - { runner: macos-latest,   target: aarch64 }
+          # one universal2 wheel (arm64 + x86_64) on the plentiful arm64 runner — avoids the scarce
+          # macos-13 (Intel) runners that otherwise stall the matrix
+          - { runner: macos-latest,   target: universal2-apple-darwin }
           - { runner: windows-latest, target: x64 }
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
The `macos-13` Intel wheel job stalled ~48 min waiting for a runner and blocked the v0.1.0 publish (all other wheels + sdist succeeded). Build one **universal2** (arm64+x86_64) macOS wheel on the plentiful `macos-latest` arm64 runner instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)