### PR TITLE
release: include LICENSE in sdist (fix 0.1.0 sdist upload)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -73,3 +73,5 @@ jobs:
           path: dist
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true  # 0.1.0 wheels are already published; re-runs only add the sdist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ python-source = "."
 manifest-path = "signwriting_similarity_rs/Cargo.toml"
 module-name = "signwriting_evaluation._similarity_rs"
 include = [
+    "LICENSE",  # maturin records License-File: LICENSE in the metadata, so it must be in the sdist too
     "signwriting_evaluation/metrics/similarity_v2/base_symbol_names.json",
     "signwriting_evaluation/metrics/similarity_v2/similarity_v2.md",
 ]


### PR DESCRIPTION
The 0.1.0 sdist was rejected by PyPI: `400 License-File LICENSE does not exist in distribution file` — maturin records `License-File: LICENSE` but didn't bundle it. All 4 wheels published fine. Add `LICENSE` to the maturin include, and `skip-existing` so re-running only uploads the missing sdist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)